### PR TITLE
Allow anonymous comments with optional name reservation

### DIFF
--- a/prisma/migrations/20260908153648_add_comment_handles/migration.sql
+++ b/prisma/migrations/20260908153648_add_comment_handles/migration.sql
@@ -1,0 +1,26 @@
+-- DropForeignKey
+ALTER TABLE "Comment" DROP CONSTRAINT "Comment_authorId_fkey";
+
+-- AlterTable
+ALTER TABLE "Comment" ADD COLUMN     "displayName" VARCHAR(20),
+ADD COLUMN     "handleId" INTEGER,
+ALTER COLUMN "authorId" DROP NOT NULL;
+
+-- CreateTable
+CREATE TABLE "CommentHandle" (
+    "id" SERIAL NOT NULL,
+    "username" VARCHAR(20) NOT NULL,
+    "passwordHash" VARCHAR(255) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CommentHandle_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CommentHandle_username_key" ON "CommentHandle"("username");
+
+-- AddForeignKey
+ALTER TABLE "Comment" ADD CONSTRAINT "Comment_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Comment" ADD CONSTRAINT "Comment_handleId_fkey" FOREIGN KEY ("handleId") REFERENCES "CommentHandle"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,14 +43,25 @@ model event {
   comments    Comment[]
 }
 
+model CommentHandle {
+  id           Int       @id @default(autoincrement())
+  username     String    @unique @db.VarChar(20)
+  passwordHash String    @db.VarChar(255)
+  createdAt    DateTime  @default(now())
+  comments     Comment[]
+}
+
 model Comment {
-  id        Int      @id @default(autoincrement())
-  body      String   @db.VarChar(1000)
-  createdAt DateTime @default(now())
-  event     event    @relation(fields: [eventId], references: [id], onDelete: Cascade)
-  eventId   Int
-  author    User     @relation(fields: [authorId], references: [id])
-  authorId  Int
+  id          Int            @id @default(autoincrement())
+  body        String         @db.VarChar(1000)
+  createdAt   DateTime       @default(now())
+  event       event          @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  eventId     Int
+  author      User?          @relation(fields: [authorId], references: [id])
+  authorId    Int?
+  handle      CommentHandle? @relation(fields: [handleId], references: [id])
+  handleId    Int?
+  displayName String?        @db.VarChar(20)
 }
 
 // Single-row hit counter (one row, id = 1). Stores no personal data.

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -358,6 +358,24 @@ button {
   align-items: flex-end; /* right-align the Post button */
 }
 
+.comment-form-links {
+  align-self: stretch;
+  text-align: left;
+  margin: 0.4rem 0;
+  font-size: 0.85em;
+  color: #333;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: #f0efef; /* matches .event-link a */
+  text-decoration: underline;
+  cursor: pointer;
+}
+
 #commentForm textarea {
   width: 100%;
   box-sizing: border-box; /* padding doesn't push it past 100% width */

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -335,6 +335,10 @@ button {
   margin: 0 0 0.3rem 0;
 }
 
+.comment-meta span {
+  font-weight: bold;
+}
+
 .comment-body {
   margin: 0;
   color: white;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -189,9 +189,23 @@ button {
   text-align: center;
 }
 
-#editButton {
+#editButton:not([hidden]) {
   display: block;
   margin-left: auto; /* right-align the edit button */
+}
+
+#backLink {
+  display: inline-block;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem 0.9rem; /* larger tap target for mobile */
+  border: 1px solid #333;
+  background-color: #ccc;
+  color: black;
+  text-decoration: none;
+}
+
+#cancelButton {
+  margin-left: 0.5rem;
 }
 
 #headerImage {
@@ -333,10 +347,6 @@ button {
   font-size: 0.85em;
   color: #eceaea;
   margin: 0 0 0.3rem 0;
-}
-
-.comment-meta span {
-  font-weight: bold;
 }
 
 .comment-body {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -348,7 +348,7 @@ button {
 }
 
 .comment-name-unclaimed {
-  color: #999; /* muted, deliberately uncolored — "anyone could have typed this" */
+  color: #555; /* muted relative to a colored username, but still readable against the #999 comment background — "anyone could have typed this" */
 }
 
 #commentForm {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -358,8 +358,11 @@ button {
   align-items: flex-end; /* right-align the Post button */
 }
 
-.comment-form-links {
+#anonymousFields {
   align-self: stretch;
+}
+
+.comment-form-links {
   text-align: left;
   margin: 0.4rem 0;
   font-size: 0.85em;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -347,6 +347,10 @@ button {
   align-self: flex-end; /* right-align the delete button */
 }
 
+.comment-name-unclaimed {
+  color: #999; /* muted, deliberately uncolored — "anyone could have typed this" */
+}
+
 #commentForm {
   margin-top: 1rem;
   display: flex;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -118,6 +118,49 @@ button {
   display: none;
 }
 
+#event .event-image {
+  cursor: pointer;
+}
+
+.image-dialog {
+  position: relative;
+  border: none;
+  padding: 0;
+  background: transparent;
+  max-width: 90vw;
+  max-height: 90vh;
+}
+
+.image-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.7);
+}
+
+.image-dialog img {
+  display: block;
+  width: 90vw;
+  height: 90vh;
+  object-fit: contain;
+}
+
+.image-dialog-close {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 44px;
+  height: 44px;
+  border: none;
+  background: rgba(0, 0, 0, 0.6);
+  color: #f0efef;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.image-dialog-close:focus-visible {
+  outline: 2px solid #f0efef;
+  outline-offset: -4px;
+}
+
 #eventList .event-image {
   margin-bottom: 3%;
   cursor: pointer;

--- a/public/js/api.js
+++ b/public/js/api.js
@@ -36,7 +36,17 @@ export const createEvent = (data) => request("POST", "/addEvent", data);
 export const removeEvent = (id) => request("DELETE", `/event/${id}`);
 export const updateEvent = (id, data) => request("PUT", `/event/${id}`, data);
 export const fetchComments = (eventId) => request("GET", `/event/${eventId}/comments`);
-export const postComment = (eventId, body) => request("POST", `/event/${eventId}/comments`, { body });
+export const postComment = (eventId, data) => request("POST", `/event/${eventId}/comments`, data);
+export const loginHandle = (username, password) =>
+  request("POST", "/comment-handles/login", { username, password });
+let handleSessionPromise;
+export function getHandleSession() {
+  handleSessionPromise ??= request("GET", "/comment-handles/me").catch(() => null);
+  return handleSessionPromise;
+}
+export function resetHandleSessionCache() {
+  handleSessionPromise = undefined;
+}
 export const removeComment = (id) => request("DELETE", `/comment/${id}`);
 export const hitCounter = () => request("POST", "/counter/hit");
 

--- a/public/js/comments.js
+++ b/public/js/comments.js
@@ -93,10 +93,10 @@ function renderComment(c, me) {
     nameSpan.textContent = c.author.username;
     nameSpan.classList.add(usernameColorClass(c.author.username));
   } else if (c.handle) {
-    nameSpan.textContent = `${c.handle.username}*`;
+    nameSpan.textContent = c.handle.username;
     nameSpan.classList.add(usernameColorClass(c.handle.username));
   } else {
-    nameSpan.textContent = c.displayName || "anonym";
+    nameSpan.textContent = `${c.displayName || "anonym"}*`;
     nameSpan.classList.add("comment-name-unclaimed");
   }
   meta.appendChild(nameSpan);

--- a/public/js/comments.js
+++ b/public/js/comments.js
@@ -87,7 +87,7 @@ function renderComment(c, me) {
     nameSpan.textContent = c.author.username;
     nameSpan.classList.add(usernameColorClass(c.author.username));
   } else if (c.handle) {
-    nameSpan.textContent = `${c.handle.username} ✓`;
+    nameSpan.textContent = `${c.handle.username}*`;
     nameSpan.classList.add(usernameColorClass(c.handle.username));
   } else {
     nameSpan.textContent = c.displayName || "anonym";

--- a/public/js/comments.js
+++ b/public/js/comments.js
@@ -1,12 +1,30 @@
-import { fetchComments, postComment, removeComment, getSession } from "./api.js";
+import {
+  fetchComments,
+  postComment,
+  removeComment,
+  getSession,
+  getHandleSession,
+  loginHandle,
+  resetHandleSessionCache,
+} from "./api.js";
 import { formatDate } from "./format.js";
 import { usernameColorClass } from "./usernameColor.js";
 
 const eventId = new URLSearchParams(window.location.search).get("id");
 const listEl = document.getElementById("commentList");
 const formEl = document.getElementById("commentForm");
+const nameEl = document.getElementById("commentName");
 const bodyEl = document.getElementById("commentBody");
 const errorEl = document.getElementById("commentError");
+const toggleLoginEl = document.getElementById("toggleLogin");
+const loginFieldsEl = document.getElementById("loginFields");
+const loginPasswordEl = document.getElementById("loginPassword");
+const loginSubmitEl = document.getElementById("loginSubmit");
+const toggleReserveEl = document.getElementById("toggleReserve");
+const reserveFieldsEl = document.getElementById("reserveFields");
+const reservePasswordEl = document.getElementById("reservePassword");
+
+let activeHandleId = null;
 
 document.addEventListener("DOMContentLoaded", init);
 
@@ -21,10 +39,32 @@ async function init() {
   }
 
   await renderComments(me);
+  await refreshFormForSession(me);
 
-  if (me) {
-    formEl.removeAttribute("hidden");
-    formEl.addEventListener("submit", (e) => onSubmit(e, me));
+  toggleLoginEl.addEventListener("click", () => {
+    loginFieldsEl.toggleAttribute("hidden");
+  });
+  toggleReserveEl.addEventListener("click", () => {
+    reserveFieldsEl.toggleAttribute("hidden");
+  });
+  loginSubmitEl.addEventListener("click", () => onLoginAndRetry(me));
+  formEl.addEventListener("submit", (e) => onSubmit(e, me));
+}
+
+// Locks the name field and hides the login/reserve toggles once a handle
+// session already exists (fresh visit with a still-valid handleToken, or
+// right after a successful reserve/login in this same page load).
+async function refreshFormForSession(me) {
+  if (me) return; // a real login always takes priority; nothing to check
+  const handle = await getHandleSession();
+  if (handle) {
+    activeHandleId = handle.handleId;
+    nameEl.value = handle.username;
+    nameEl.readOnly = true;
+    toggleLoginEl.setAttribute("hidden", "");
+    toggleReserveEl.setAttribute("hidden", "");
+    loginFieldsEl.setAttribute("hidden", "");
+    reserveFieldsEl.setAttribute("hidden", "");
   }
 }
 
@@ -42,11 +82,18 @@ function renderComment(c, me) {
 
   const meta = document.createElement("p");
   meta.className = "comment-meta";
-  const name = c.author?.username ?? "unknown";
-  const nameEl = document.createElement("span");
-  nameEl.textContent = name; // SAFE: text, not HTML
-  nameEl.classList.add(usernameColorClass(name));
-  meta.appendChild(nameEl);
+  const nameSpan = document.createElement("span");
+  if (c.author) {
+    nameSpan.textContent = c.author.username;
+    nameSpan.classList.add(usernameColorClass(c.author.username));
+  } else if (c.handle) {
+    nameSpan.textContent = `${c.handle.username} ✓`;
+    nameSpan.classList.add(usernameColorClass(c.handle.username));
+  } else {
+    nameSpan.textContent = c.displayName || "anonym";
+    nameSpan.classList.add("comment-name-unclaimed");
+  }
+  meta.appendChild(nameSpan);
   meta.appendChild(document.createTextNode(` · ${formatDate(c.createdAt)}`));
 
   const bodyP = document.createElement("p");
@@ -56,7 +103,9 @@ function renderComment(c, me) {
   li.appendChild(meta);
   li.appendChild(bodyP);
 
-  const canDelete = me && (me.role === "ADMIN" || c.authorId === me.userId);
+  const canDelete =
+    (me && (me.role === "ADMIN" || c.authorId === me.userId)) ||
+    (activeHandleId && c.handleId === activeHandleId);
   if (canDelete) {
     const del = document.createElement("button");
     del.type = "button";
@@ -75,16 +124,53 @@ function renderComment(c, me) {
   return li;
 }
 
+async function onLoginAndRetry(me) {
+  errorEl.setAttribute("hidden", "");
+  const username = nameEl.value.trim();
+  const password = loginPasswordEl.value;
+  try {
+    await loginHandle(username, password);
+    resetHandleSessionCache();
+    loginPasswordEl.value = "";
+    await refreshFormForSession(me);
+    // Retry the comment the visitor was already trying to post.
+    if (bodyEl.value.trim()) {
+      await onSubmit(new Event("submit"), me);
+    }
+  } catch (err) {
+    errorEl.textContent = err.message || "kunde inte logga in";
+    errorEl.removeAttribute("hidden");
+  }
+}
+
 async function onSubmit(e, me) {
   e.preventDefault();
   errorEl.setAttribute("hidden", "");
   const body = bodyEl.value.trim();
   if (!body) return;
+
+  const reserving = !reserveFieldsEl.hasAttribute("hidden");
+  const data = { body };
+  if (!nameEl.readOnly) {
+    const name = nameEl.value.trim();
+    if (name) data.name = name;
+    if (reserving && name) {
+      data.reserve = true;
+      data.password = reservePasswordEl.value;
+    }
+  }
+
   try {
-    await postComment(eventId, body);
+    await postComment(eventId, data);
     bodyEl.value = "";
+    reservePasswordEl.value = "";
+    resetHandleSessionCache();
     await renderComments(me);
+    await refreshFormForSession(me);
   } catch (err) {
+    if (err.message && err.message.includes("reserverat")) {
+      loginFieldsEl.removeAttribute("hidden");
+    }
     errorEl.textContent = err.message || "kunde inte skicka kommentaren";
     errorEl.removeAttribute("hidden");
   }

--- a/public/js/comments.js
+++ b/public/js/comments.js
@@ -13,6 +13,7 @@ import { usernameColorClass } from "./usernameColor.js";
 const eventId = new URLSearchParams(window.location.search).get("id");
 const listEl = document.getElementById("commentList");
 const formEl = document.getElementById("commentForm");
+const anonymousFieldsEl = document.getElementById("anonymousFields");
 const nameEl = document.getElementById("commentName");
 const bodyEl = document.getElementById("commentBody");
 const errorEl = document.getElementById("commentError");
@@ -55,7 +56,12 @@ async function init() {
 // session already exists (fresh visit with a still-valid handleToken, or
 // right after a successful reserve/login in this same page load).
 async function refreshFormForSession(me) {
-  if (me) return; // a real login always takes priority; nothing to check
+  if (me) {
+    // A real login always takes priority — the anonymous name/reserve UI
+    // would be confusing clutter for someone already posting as themselves.
+    anonymousFieldsEl.setAttribute("hidden", "");
+    return;
+  }
   const handle = await getHandleSession();
   if (handle) {
     activeHandleId = handle.handleId;

--- a/public/js/getEvent.js
+++ b/public/js/getEvent.js
@@ -18,7 +18,30 @@ class EventDetail {
 const urlParams = new URLSearchParams(window.location.search);
 const eventId = urlParams.get("id");
 
-document.addEventListener("DOMContentLoaded", () => getEvent(eventId));
+document.addEventListener("DOMContentLoaded", () => {
+  getEvent(eventId);
+  setupImageDialog();
+});
+
+function setupImageDialog() {
+  const imageEl = document.getElementById("image");
+  const dialog = document.getElementById("imageDialog");
+  const dialogImg = document.getElementById("imageDialogImg");
+  const closeButton = document.getElementById("imageDialogClose");
+
+  imageEl.addEventListener("click", () => {
+    if (!imageEl.src) return;
+    dialogImg.src = imageEl.src;
+    dialogImg.alt = imageEl.alt;
+    dialog.showModal();
+  });
+
+  dialog.addEventListener("click", (e) => {
+    if (e.target === dialog) dialog.close();
+  });
+
+  closeButton.addEventListener("click", () => dialog.close());
+}
 
 async function getEvent(eventId) {
   if (!eventId) {

--- a/public/js/getEvents.js
+++ b/public/js/getEvents.js
@@ -71,7 +71,7 @@ function renderEvents(events, me) {
     createAndAppend("p", eventBody, { text: `plats: ${event.location}` });
     if (event.link) {
       const linkBlock = createAndAppend("div", eventBody, { class: "event-link" });
-      createAndAppend("a", linkBlock, { text: "öppna länk", href: event.link });
+      createAndAppend("a", linkBlock, { text: event.link, href: event.link });
     }
     const goToDetails = () => {
       window.location.href = `/pages/event.html?id=${event.id}`;

--- a/public/js/postEvent.js
+++ b/public/js/postEvent.js
@@ -25,6 +25,9 @@ class PostEvent {
       "change",
       this.previewSelectedImage.bind(this),
     );
+    document
+      .getElementById("cancelButton")
+      .addEventListener("click", this.handleCancel.bind(this));
     if (eventId) {
       this.enterEditMode(eventId);
     } else {
@@ -88,6 +91,12 @@ class PostEvent {
     this.prefillForm(existing);
     document.getElementById("formTitle").textContent = "ändra event";
     document.getElementById("submitButton").textContent = "spara";
+  }
+
+  handleCancel() {
+    window.location.href = this.eventId
+      ? `/pages/event.html?id=${this.eventId}`
+      : "/";
   }
 
   blockForm(message) {

--- a/public/pages/addEvent.html
+++ b/public/pages/addEvent.html
@@ -61,6 +61,7 @@
       </div>
       <p class="required-note"><span class="required-asterisk">*</span> obligatoriskt fält</p>
       <button type="submit" id="submitButton">skapa</button>
+      <button type="button" id="cancelButton">avbryt</button>
       <p id="formError" hidden class="form-error"></p>
     </form>
     <script type="module" src="../js/postEvent.js"></script>

--- a/public/pages/event.html
+++ b/public/pages/event.html
@@ -40,21 +40,24 @@
             maxlength="20"
             placeholder="anonym"
           />
+          <p class="comment-form-links">
+            <button type="button" id="toggleLogin" class="link-button">har du ett reserverat namn? logga in</button>
+            ·
+            <button type="button" id="toggleReserve" class="link-button">reservera detta namn</button>
+          </p>
+          <div id="loginFields" hidden>
+            <input id="loginPassword" type="password" placeholder="lösenord" />
+            <button type="button" id="loginSubmit" class="button">logga in</button>
+          </div>
+          <div id="reserveFields" hidden>
+            <input id="reservePassword" type="password" placeholder="välj ett lösenord" />
+          </div>
           <textarea
             id="commentBody"
             maxlength="1000"
             required
             placeholder="skriv en kommentar"
           ></textarea>
-          <button type="button" id="toggleLogin" class="button">har du ett reserverat namn? logga in</button>
-          <div id="loginFields" hidden>
-            <input id="loginPassword" type="password" placeholder="lösenord" />
-            <button type="button" id="loginSubmit" class="button">logga in</button>
-          </div>
-          <button type="button" id="toggleReserve" class="button">reservera detta namn</button>
-          <div id="reserveFields" hidden>
-            <input id="reservePassword" type="password" placeholder="välj ett lösenord" />
-          </div>
           <p id="commentError" hidden></p>
           <button type="submit" class="button">skicka</button>
         </form>

--- a/public/pages/event.html
+++ b/public/pages/event.html
@@ -33,13 +33,28 @@
       <section id="comments">
         <h2>kommentarer</h2>
         <ul id="commentList"></ul>
-        <form id="commentForm" hidden>
+        <form id="commentForm">
+          <input
+            id="commentName"
+            type="text"
+            maxlength="20"
+            placeholder="anonym"
+          />
           <textarea
             id="commentBody"
             maxlength="1000"
             required
             placeholder="skriv en kommentar"
           ></textarea>
+          <button type="button" id="toggleLogin" class="button">har du ett reserverat namn? logga in</button>
+          <div id="loginFields" hidden>
+            <input id="loginPassword" type="password" placeholder="lösenord" />
+            <button type="button" id="loginSubmit" class="button">logga in</button>
+          </div>
+          <button type="button" id="toggleReserve" class="button">reservera detta namn</button>
+          <div id="reserveFields" hidden>
+            <input id="reservePassword" type="password" placeholder="välj ett lösenord" />
+          </div>
           <p id="commentError" hidden></p>
           <button type="submit" class="button">skicka</button>
         </form>

--- a/public/pages/event.html
+++ b/public/pages/event.html
@@ -20,6 +20,10 @@
             <p id="author"></p>
           </div>
           <img id="image" class="event-image" src="" alt="" />
+          <dialog id="imageDialog" class="image-dialog">
+            <button type="button" id="imageDialogClose" class="image-dialog-close" aria-label="stäng">&times;</button>
+            <img id="imageDialogImg" alt="" />
+          </dialog>
           <p id="description"></p>
           <a
             id="link"

--- a/public/pages/event.html
+++ b/public/pages/event.html
@@ -34,23 +34,25 @@
         <h2>kommentarer</h2>
         <ul id="commentList"></ul>
         <form id="commentForm">
-          <input
-            id="commentName"
-            type="text"
-            maxlength="20"
-            placeholder="anonym"
-          />
-          <p class="comment-form-links">
-            <button type="button" id="toggleLogin" class="link-button">har du ett reserverat namn? logga in</button>
-            ·
-            <button type="button" id="toggleReserve" class="link-button">reservera detta namn</button>
-          </p>
-          <div id="loginFields" hidden>
-            <input id="loginPassword" type="password" placeholder="lösenord" />
-            <button type="button" id="loginSubmit" class="button">logga in</button>
-          </div>
-          <div id="reserveFields" hidden>
-            <input id="reservePassword" type="password" placeholder="välj ett lösenord" />
+          <div id="anonymousFields">
+            <input
+              id="commentName"
+              type="text"
+              maxlength="20"
+              placeholder="anonym"
+            />
+            <p class="comment-form-links">
+              <button type="button" id="toggleLogin" class="link-button">har du ett reserverat namn? logga in</button>
+              ·
+              <button type="button" id="toggleReserve" class="link-button">reservera detta namn</button>
+            </p>
+            <div id="loginFields" hidden>
+              <input id="loginPassword" type="password" placeholder="lösenord" />
+              <button type="button" id="loginSubmit" class="button">logga in</button>
+            </div>
+            <div id="reserveFields" hidden>
+              <input id="reservePassword" type="password" placeholder="välj ett lösenord" />
+            </div>
           </div>
           <textarea
             id="commentBody"

--- a/public/pages/event.html
+++ b/public/pages/event.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="event">
+      <a id="backLink" href="/">&larr; tillbaka</a>
       <div class="event-item">
         <div class="event-header">
           <h1 id="name"></h1>

--- a/server/auth/handleSession.ts
+++ b/server/auth/handleSession.ts
@@ -1,0 +1,36 @@
+import crypto from "node:crypto";
+import jwt from "jsonwebtoken";
+
+const secret = process.env.JWT_SECRET;
+
+if (!secret || secret.length < 32) {
+  throw new Error(
+    "JWT_SECRET missing or shorter than 32 chars — refusing to start",
+  );
+}
+
+// Derived, not a second secret to configure: a token signed with this key
+// can never verify against the real login secret in ../auth/jwt.ts, or vice
+// versa — even if some future code reads the wrong cookie into the wrong
+// verify function, the signature check itself fails closed.
+const HANDLE_SECRET = crypto
+  .createHmac("sha256", secret)
+  .update("comment-handle-session")
+  .digest("hex");
+
+export type HandleSession = { handleId: number; username: string };
+
+export function signHandleToken(payload: HandleSession): string {
+  return jwt.sign(payload, HANDLE_SECRET, { expiresIn: "2h" });
+}
+
+export function verifyHandleToken(token: string): HandleSession {
+  return jwt.verify(token, HANDLE_SECRET) as HandleSession;
+}
+
+export const handleCookieOpts = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "strict" as const,
+  maxAge: 2 * 60 * 60 * 1000, // 2 hours — matches the handle-token expiry
+};

--- a/server/auth/rateLimit.ts
+++ b/server/auth/rateLimit.ts
@@ -54,3 +54,15 @@ export const loginIpLimiter = createRateLimiter({ max: 30, windowMs: 5 * 60 * 10
 // defense-in-depth against runaway loops and double-submits, not the primary
 // abuse control — invite-only trust is. Tune the numbers if they bite.
 export const commentLimiter = createRateLimiter({ max: 20, windowMs: 60 * 1000 });
+
+// Per-IP ceiling for anonymous and handle-session comments. Anonymous posts
+// have no user id to key on, and a handle session isn't elevated trust over
+// plain anonymous — both share this budget. Same shape as commentLimiter,
+// just re-anchored on IP since that's the only identity anonymous requests
+// have.
+export const anonCommentLimiter = createRateLimiter({ max: 20, windowMs: 60 * 1000 });
+
+// Mirrors loginLimiter / loginIpLimiter exactly, protecting
+// /comment-handles/login against brute-forcing a reserved handle's password.
+export const handleLoginLimiter = createRateLimiter({ max: 5, windowMs: 15 * 60 * 1000 });
+export const handleLoginIpLimiter = createRateLimiter({ max: 30, windowMs: 5 * 60 * 1000 });

--- a/server/db/commentHandles.ts
+++ b/server/db/commentHandles.ts
@@ -1,0 +1,22 @@
+import { prisma } from "./events";
+import type { CommentHandle } from "@prisma/client";
+import { getUserByUsername } from "./users";
+
+export async function getCommentHandleByUsername(
+  username: string,
+): Promise<CommentHandle | null> {
+  return prisma.commentHandle.findUnique({ where: { username } });
+}
+
+// Checked against both tables: a name is either a real invited user's
+// username or a reserved anonymous handle, never both. Used identically by
+// every code path that needs to know "is this name taken" — the comment
+// route (both the plain-anonymous and the reserve branch) — so the check
+// never drifts into two different implementations.
+export async function isNameReserved(username: string): Promise<boolean> {
+  const [handle, user] = await Promise.all([
+    getCommentHandleByUsername(username),
+    getUserByUsername(username),
+  ]);
+  return handle !== null || user !== null;
+}

--- a/server/db/comments.ts
+++ b/server/db/comments.ts
@@ -1,28 +1,54 @@
-import { Prisma } from "@prisma/client";
 import { prisma } from "./events";
+import type { Prisma } from "@prisma/client";
 
-export type CommentWithAuthor = Prisma.CommentGetPayload<{
-  include: { author: { select: { username: true } } };
+export type CommentWithIdentity = Prisma.CommentGetPayload<{
+  include: {
+    author: { select: { username: true } };
+    handle: { select: { username: true } };
+  };
 }>;
+
+const commentInclude = {
+  author: { select: { username: true } },
+  handle: { select: { username: true } },
+} as const;
 
 export async function listCommentsForEvent(
   eventId: number,
-): Promise<CommentWithAuthor[]> {
+): Promise<CommentWithIdentity[]> {
   return prisma.comment.findMany({
     where: { eventId },
     orderBy: { createdAt: "asc" }, // oldest-first
-    include: { author: { select: { username: true } } },
+    include: commentInclude,
   });
 }
 
-export async function createComment(
+export async function createComment(data: {
+  eventId: number;
+  body: string;
+  authorId?: number;
+  handleId?: number;
+  displayName?: string | null;
+}): Promise<CommentWithIdentity> {
+  return prisma.comment.create({ data, include: commentInclude });
+}
+
+// Reserving a name is always bundled with posting the first comment under
+// it — never a standalone action. Both inserts happen in one transaction so
+// a failure partway through never leaves an orphaned reservation with no
+// comment behind it.
+export async function createHandleAndComment(
   eventId: number,
-  authorId: number,
+  username: string,
+  passwordHash: string,
   body: string,
-): Promise<CommentWithAuthor> {
-  return prisma.comment.create({
-    data: { eventId, authorId, body },
-    include: { author: { select: { username: true } } },
+): Promise<CommentWithIdentity> {
+  return prisma.$transaction(async (tx) => {
+    const handle = await tx.commentHandle.create({ data: { username, passwordHash } });
+    return tx.comment.create({
+      data: { eventId, body, handleId: handle.id },
+      include: commentInclude,
+    });
   });
 }
 

--- a/server/db/users.ts
+++ b/server/db/users.ts
@@ -9,6 +9,10 @@ export async function getUserById(id: number): Promise<User | null> {
   return prisma.user.findUnique({ where: { id } });
 }
 
+export async function getUserByUsername(username: string): Promise<User | null> {
+  return prisma.user.findUnique({ where: { username } });
+}
+
 export async function createUser(data: {
   email: string;
   passwordHash: string;

--- a/server/domain/comments.ts
+++ b/server/domain/comments.ts
@@ -1,4 +1,12 @@
-type NewComment = { body: string };
+import { validateUsername } from "./username";
+import { validatePassword } from "./password";
+
+type NewComment = {
+  body: string;
+  name: string | null;
+  reserve: boolean;
+  password: string | null;
+};
 
 type ValidationResult =
   | { ok: true; comment: NewComment }
@@ -10,11 +18,31 @@ export function validateNewComment(input: unknown): ValidationResult {
   }
   const i = input as Record<string, unknown>;
   const body = typeof i.body === "string" ? i.body.trim() : "";
+  const rawName = typeof i.name === "string" ? i.name.trim() : "";
+  const reserve = i.reserve === true;
+  const password = typeof i.password === "string" ? i.password : "";
 
   const errors: string[] = [];
   if (!body) errors.push("body is required");
   else if (body.length > 1000) errors.push("body must be 1000 characters or fewer");
 
+  if (reserve) {
+    const usernameError = rawName ? validateUsername(rawName) : "name is required to reserve it";
+    if (usernameError) errors.push(usernameError);
+    const passwordError = password ? validatePassword(password) : "password is required to reserve a name";
+    if (passwordError) errors.push(passwordError);
+  } else if (rawName.length > 20) {
+    errors.push("name must be 20 characters or fewer");
+  }
+
   if (errors.length > 0) return { ok: false, errors };
-  return { ok: true, comment: { body } };
+  return {
+    ok: true,
+    comment: {
+      body,
+      name: rawName || null,
+      reserve,
+      password: reserve ? password : null,
+    },
+  };
 }

--- a/server/domain/permissions.ts
+++ b/server/domain/permissions.ts
@@ -16,7 +16,14 @@ export function canEditEvent(
 
 export function canDeleteComment(
   user: AuthUser,
-  comment: { authorId: number },
+  comment: { authorId: number | null },
 ): boolean {
   return user.role === "ADMIN" || comment.authorId === user.userId;
+}
+
+export function canDeleteHandleComment(
+  handleId: number,
+  comment: { handleId: number | null },
+): boolean {
+  return comment.handleId === handleId;
 }

--- a/server/middleware/commentIdentity.ts
+++ b/server/middleware/commentIdentity.ts
@@ -1,0 +1,31 @@
+import type { Context } from "koa";
+import type { Role } from "@prisma/client";
+import { verifyToken } from "../auth/jwt";
+import { verifyHandleToken } from "../auth/handleSession";
+
+export type CommentIdentity =
+  | { kind: "user"; userId: number; role: Role }
+  | { kind: "handle"; handleId: number; username: string }
+  | { kind: "anonymous" };
+
+export function getCommentIdentity(ctx: Context): CommentIdentity {
+  const token = ctx.cookies.get("token");
+  if (token) {
+    try {
+      const payload = verifyToken(token);
+      return { kind: "user", userId: payload.userId, role: payload.role };
+    } catch {
+      // fall through — try a handle session next
+    }
+  }
+  const handleToken = ctx.cookies.get("handleToken");
+  if (handleToken) {
+    try {
+      const payload = verifyHandleToken(handleToken);
+      return { kind: "handle", handleId: payload.handleId, username: payload.username };
+    } catch {
+      // fall through — anonymous
+    }
+  }
+  return { kind: "anonymous" };
+}

--- a/server/routes/commentHandles.ts
+++ b/server/routes/commentHandles.ts
@@ -1,0 +1,54 @@
+import Router from "@koa/router";
+import { getCommentHandleByUsername } from "../db/commentHandles";
+import { signHandleToken, verifyHandleToken, handleCookieOpts } from "../auth/handleSession";
+import { handleLoginLimiter, handleLoginIpLimiter } from "../auth/rateLimit";
+
+export const commentHandlesRouter = new Router();
+
+commentHandlesRouter.post("/comment-handles/login", async (ctx) => {
+  const body = ctx.request.body as { username?: unknown; password?: unknown };
+  const username = typeof body.username === "string" ? body.username.trim() : "";
+  const password = typeof body.password === "string" ? body.password : "";
+
+  const ip = ctx.ip;
+  if (!handleLoginIpLimiter.consume(ip) || !handleLoginLimiter.consume(username)) {
+    ctx.status = 429;
+    ctx.body = { error: "Too many login attempts. Try again later." };
+    return;
+  }
+
+  const handle = await getCommentHandleByUsername(username);
+  // Verify against a hash either way, even for an unknown username, so a
+  // missing handle doesn't respond faster than a wrong password (a timing
+  // side-channel revealing which names are registered) — same pattern as
+  // /auth/login.
+  const dummyHash =
+    "$argon2id$v=19$m=65536,t=2,p=1$00000000000000000000000000000000$0000000000000000000000000000000000000000000000000000000000000000";
+  const passwordOk = await Bun.password.verify(password, handle?.passwordHash ?? dummyHash);
+
+  if (!handle || !passwordOk) {
+    ctx.status = 401;
+    ctx.body = { error: "Fel namn eller lösenord" };
+    return;
+  }
+
+  handleLoginLimiter.reset(username);
+  handleLoginIpLimiter.reset(ip);
+  const token = signHandleToken({ handleId: handle.id, username: handle.username });
+  ctx.cookies.set("handleToken", token, handleCookieOpts);
+  ctx.status = 204;
+});
+
+commentHandlesRouter.get("/comment-handles/me", async (ctx) => {
+  const cookie = ctx.cookies.get("handleToken");
+  if (!cookie) {
+    ctx.status = 401;
+    return;
+  }
+  try {
+    const payload = verifyHandleToken(cookie);
+    ctx.body = { handleId: payload.handleId, username: payload.username };
+  } catch {
+    ctx.status = 401;
+  }
+});

--- a/server/routes/comments.ts
+++ b/server/routes/comments.ts
@@ -1,17 +1,23 @@
+import { Prisma } from "@prisma/client";
 import Router from "@koa/router";
 import { getEventById } from "../db/events";
 import {
   listCommentsForEvent,
   createComment,
+  createHandleAndComment,
   getCommentById,
   deleteComment,
 } from "../db/comments";
+import { isNameReserved } from "../db/commentHandles";
 import { validateNewComment } from "../domain/comments";
-import { canDeleteComment } from "../domain/permissions";
-import { requireAuth } from "../middleware/auth";
-import { commentLimiter } from "../auth/rateLimit";
+import { canDeleteComment, canDeleteHandleComment } from "../domain/permissions";
+import { getCommentIdentity } from "../middleware/commentIdentity";
+import { signHandleToken, handleCookieOpts } from "../auth/handleSession";
+import { commentLimiter, anonCommentLimiter } from "../auth/rateLimit";
 
 export const commentsRouter = new Router();
+
+const NAME_TAKEN_ERROR = "Det namnet är reserverat — logga in eller välj ett annat";
 
 commentsRouter.get("/event/:id/comments", async (ctx) => {
   const eventId = Number(ctx.params.id);
@@ -22,7 +28,7 @@ commentsRouter.get("/event/:id/comments", async (ctx) => {
   ctx.body = await listCommentsForEvent(eventId);
 });
 
-commentsRouter.post("/event/:id/comments", requireAuth, async (ctx) => {
+commentsRouter.post("/event/:id/comments", async (ctx) => {
   const eventId = Number(ctx.params.id);
   if (isNaN(eventId)) {
     ctx.status = 404;
@@ -32,27 +38,85 @@ commentsRouter.post("/event/:id/comments", requireAuth, async (ctx) => {
     ctx.status = 404;
     return;
   }
-  if (!commentLimiter.consume(String(ctx.state.user.userId))) {
+
+  const identity = getCommentIdentity(ctx);
+  const limiter = identity.kind === "user" ? commentLimiter : anonCommentLimiter;
+  const limiterKey = identity.kind === "user" ? String(identity.userId) : ctx.ip;
+  if (!limiter.consume(limiterKey)) {
     ctx.status = 429;
     ctx.body = { error: "Too many comments, slow down" };
     return;
   }
+
   const result = validateNewComment(ctx.request.body);
   if (!result.ok) {
     ctx.status = 400;
     ctx.body = { errors: result.errors };
     return;
   }
-  const comment = await createComment(
-    eventId,
-    ctx.state.user.userId,
-    result.comment.body,
-  );
+  const { body, name, reserve, password } = result.comment;
+
+  if (identity.kind === "user") {
+    const comment = await createComment({ eventId, body, authorId: identity.userId });
+    ctx.status = 201;
+    ctx.body = comment;
+    return;
+  }
+
+  if (identity.kind === "handle") {
+    const comment = await createComment({ eventId, body, handleId: identity.handleId });
+    ctx.status = 201;
+    ctx.body = comment;
+    return;
+  }
+
+  // identity.kind === "anonymous"
+  if (reserve && name && password) {
+    if (await isNameReserved(name)) {
+      ctx.status = 409;
+      ctx.body = { error: NAME_TAKEN_ERROR };
+      return;
+    }
+    const passwordHash = await Bun.password.hash(password);
+    try {
+      const comment = await createHandleAndComment(eventId, name, passwordHash, body);
+      ctx.cookies.set(
+        "handleToken",
+        signHandleToken({ handleId: comment.handleId!, username: name }),
+        handleCookieOpts,
+      );
+      ctx.status = 201;
+      ctx.body = comment;
+    } catch (e) {
+      // A concurrent request claimed the exact same name in the gap between
+      // the isNameReserved() check above and this insert — the unique
+      // constraint on CommentHandle.username is the real, race-safe gate.
+      if (
+        e instanceof Prisma.PrismaClientKnownRequestError &&
+        e.code === "P2002" &&
+        (e.meta?.target as string[] | undefined)?.includes("username")
+      ) {
+        ctx.status = 409;
+        ctx.body = { error: NAME_TAKEN_ERROR };
+        return;
+      }
+      throw e;
+    }
+    return;
+  }
+
+  if (name && (await isNameReserved(name))) {
+    ctx.status = 409;
+    ctx.body = { error: NAME_TAKEN_ERROR };
+    return;
+  }
+
+  const comment = await createComment({ eventId, body, displayName: name });
   ctx.status = 201;
   ctx.body = comment;
 });
 
-commentsRouter.delete("/comment/:id", requireAuth, async (ctx) => {
+commentsRouter.delete("/comment/:id", async (ctx) => {
   const id = Number(ctx.params.id);
   if (isNaN(id)) {
     ctx.status = 404;
@@ -63,7 +127,17 @@ commentsRouter.delete("/comment/:id", requireAuth, async (ctx) => {
     ctx.status = 404;
     return;
   }
-  if (!canDeleteComment(ctx.state.user, existing)) {
+
+  const identity = getCommentIdentity(ctx);
+  if (identity.kind === "anonymous") {
+    ctx.status = 401;
+    return;
+  }
+  const allowed =
+    identity.kind === "user"
+      ? canDeleteComment(identity, existing)
+      : canDeleteHandleComment(identity.handleId, existing);
+  if (!allowed) {
     ctx.status = 403;
     return;
   }

--- a/server/server.ts
+++ b/server/server.ts
@@ -7,6 +7,7 @@ import serve from "koa-static";
 import dotenv from "dotenv";
 import { eventsRouter } from "./routes/events";
 import { commentsRouter } from "./routes/comments";
+import { commentHandlesRouter } from "./routes/commentHandles";
 import { counterRouter } from "./routes/counter";
 import { authRouter } from "./routes/auth";
 import { requireAuth } from "./middleware/auth";
@@ -148,6 +149,8 @@ app.use(eventsRouter.routes());
 app.use(eventsRouter.allowedMethods());
 app.use(commentsRouter.routes());
 app.use(commentsRouter.allowedMethods());
+app.use(commentHandlesRouter.routes());
+app.use(commentHandlesRouter.allowedMethods());
 app.use(counterRouter.routes());
 app.use(counterRouter.allowedMethods());
 

--- a/tests/auth/handleSession.test.ts
+++ b/tests/auth/handleSession.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { signHandleToken, verifyHandleToken } from "../../server/auth/handleSession";
+import { signToken, verifyToken } from "../../server/auth/jwt";
+
+describe("handle session helpers", () => {
+  test("signs and verifies a round trip", () => {
+    const token = signHandleToken({ handleId: 7, username: "katja" });
+    const payload = verifyHandleToken(token);
+    expect(payload.handleId).toBe(7);
+    expect(payload.username).toBe("katja");
+  });
+
+  test("rejects a tampered token", () => {
+    const token = signHandleToken({ handleId: 1, username: "x" });
+    const tampered = token.slice(0, -2) + (token.endsWith("a") ? "bb" : "aa");
+    expect(() => verifyHandleToken(tampered)).toThrow();
+  });
+
+  test("a real login token never verifies as a handle session", () => {
+    const userToken = signToken({ userId: 1, role: "ADMIN" });
+    expect(() => verifyHandleToken(userToken)).toThrow();
+  });
+
+  test("a handle session token never verifies as a real login", () => {
+    const handleToken = signHandleToken({ handleId: 1, username: "x" });
+    expect(() => verifyToken(handleToken)).toThrow();
+  });
+});

--- a/tests/domain/comments.test.ts
+++ b/tests/domain/comments.test.ts
@@ -26,6 +26,58 @@ describe("validateNewComment", () => {
   });
 });
 
+describe("validateNewComment — name/reserve/password", () => {
+  test("defaults name to null and reserve to false when omitted", () => {
+    const r = validateNewComment({ body: "hi" });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.comment.name).toBeNull();
+      expect(r.comment.reserve).toBe(false);
+      expect(r.comment.password).toBeNull();
+    }
+  });
+
+  test("accepts a plain anonymous name up to 20 characters", () => {
+    const r = validateNewComment({ body: "hi", name: "  Katja  " });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.comment.name).toBe("Katja");
+  });
+
+  test("rejects a plain anonymous name over 20 characters", () => {
+    expect(validateNewComment({ body: "hi", name: "a".repeat(21) }).ok).toBe(false);
+  });
+
+  test("reserve requires a valid username", () => {
+    const r = validateNewComment({ body: "hi", reserve: true, name: "ab", password: "a-decent-passphrase" });
+    expect(r.ok).toBe(false);
+  });
+
+  test("reserve requires a valid password", () => {
+    const r = validateNewComment({ body: "hi", reserve: true, name: "katja", password: "short" });
+    expect(r.ok).toBe(false);
+  });
+
+  test("reserve requires both name and password to be present", () => {
+    expect(validateNewComment({ body: "hi", reserve: true, password: "a-decent-passphrase" }).ok).toBe(false);
+    expect(validateNewComment({ body: "hi", reserve: true, name: "katja" }).ok).toBe(false);
+  });
+
+  test("accepts a valid reserve request", () => {
+    const r = validateNewComment({
+      body: "hi",
+      reserve: true,
+      name: "katja",
+      password: "a-decent-passphrase",
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.comment.name).toBe("katja");
+      expect(r.comment.reserve).toBe(true);
+      expect(r.comment.password).toBe("a-decent-passphrase");
+    }
+  });
+});
+
 describe("canDeleteComment", () => {
   const comment = { authorId: 7 };
   test("author can delete", () => {

--- a/tests/domain/permissions.test.ts
+++ b/tests/domain/permissions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { canDeleteEvent, canEditEvent } from "../../server/domain/permissions";
+import { canDeleteEvent, canEditEvent, canDeleteHandleComment } from "../../server/domain/permissions";
 
 describe("delete event permissions", () => {
   test("user with role ADMIN can delete event", () => {
@@ -42,5 +42,19 @@ describe("edit event permissions", () => {
     const userId = 1; // ID of the user attempting to edit the event
     const createdById = 2; // ID of the user who created the event
     expect(canEditEvent({ userId, role }, { createdById })).toBe(false);
+  });
+});
+
+describe("canDeleteHandleComment", () => {
+  test("the same handle can delete its own comment", () => {
+    expect(canDeleteHandleComment(7, { handleId: 7 })).toBe(true);
+  });
+
+  test("a different handle cannot delete it", () => {
+    expect(canDeleteHandleComment(8, { handleId: 7 })).toBe(false);
+  });
+
+  test("a plain anonymous comment (no handle) cannot be deleted this way", () => {
+    expect(canDeleteHandleComment(7, { handleId: null })).toBe(false);
   });
 });

--- a/tests/middleware/commentIdentity.test.ts
+++ b/tests/middleware/commentIdentity.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import type { Context } from "koa";
+import { getCommentIdentity } from "../../server/middleware/commentIdentity";
+import { signToken } from "../../server/auth/jwt";
+import { signHandleToken } from "../../server/auth/handleSession";
+
+function fakeCtx(cookies: Record<string, string>): Context {
+  return { cookies: { get: (name: string) => cookies[name] } } as unknown as Context;
+}
+
+describe("getCommentIdentity", () => {
+  test("returns a user identity from a valid token cookie", () => {
+    const token = signToken({ userId: 5, role: "CONTRIBUTOR" });
+    expect(getCommentIdentity(fakeCtx({ token }))).toEqual({
+      kind: "user",
+      userId: 5,
+      role: "CONTRIBUTOR",
+    });
+  });
+
+  test("returns a handle identity from a valid handleToken cookie", () => {
+    const handleToken = signHandleToken({ handleId: 3, username: "katja" });
+    expect(getCommentIdentity(fakeCtx({ handleToken }))).toEqual({
+      kind: "handle",
+      handleId: 3,
+      username: "katja",
+    });
+  });
+
+  test("prefers a real user session over a handle cookie if both are present", () => {
+    const token = signToken({ userId: 5, role: "CONTRIBUTOR" });
+    const handleToken = signHandleToken({ handleId: 3, username: "katja" });
+    expect(getCommentIdentity(fakeCtx({ token, handleToken })).kind).toBe("user");
+  });
+
+  test("falls back to anonymous with no cookies", () => {
+    expect(getCommentIdentity(fakeCtx({}))).toEqual({ kind: "anonymous" });
+  });
+
+  test("falls back to anonymous with an invalid token", () => {
+    expect(getCommentIdentity(fakeCtx({ token: "garbage" }))).toEqual({ kind: "anonymous" });
+  });
+});

--- a/tests/routes/commentHandles.test.ts
+++ b/tests/routes/commentHandles.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test, beforeAll, afterAll, afterEach } from "bun:test";
+import { app } from "../../server/server";
+import { prisma } from "../../server/db/events";
+import { signHandleToken } from "../../server/auth/handleSession";
+
+let server: ReturnType<typeof app.listen>;
+let baseUrl: string;
+
+beforeAll(() => {
+  server = app.listen(0);
+  baseUrl = `http://localhost:${(server.address() as { port: number }).port}`;
+});
+afterAll(async () => {
+  server.close();
+  await prisma.$disconnect();
+});
+afterEach(async () => {
+  await prisma.commentHandle.deleteMany();
+});
+
+async function makeHandle(username: string, password: string) {
+  return prisma.commentHandle.create({
+    data: { username, passwordHash: await Bun.password.hash(password) },
+  });
+}
+
+describe("POST /comment-handles/login", () => {
+  test("valid credentials set a handleToken cookie and return 204", async () => {
+    await makeHandle("regular", "a-decent-passphrase");
+    const res = await fetch(`${baseUrl}/comment-handles/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: "regular", password: "a-decent-passphrase" }),
+    });
+    expect(res.status).toBe(204);
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("handleToken=");
+    expect(setCookie.toLowerCase()).toContain("httponly");
+  });
+
+  test("wrong password returns a generic 401", async () => {
+    await makeHandle("regular", "a-decent-passphrase");
+    const res = await fetch(`${baseUrl}/comment-handles/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: "regular", password: "wrongpassword" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("unknown username returns the same generic 401", async () => {
+    const res = await fetch(`${baseUrl}/comment-handles/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: "nobody", password: "whateverpass" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("blocks with 429 after too many failed attempts", async () => {
+    await makeHandle("regular2", "a-decent-passphrase");
+    for (let i = 0; i < 5; i++) {
+      const r = await fetch(`${baseUrl}/comment-handles/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username: "regular2", password: "wrongpassword" }),
+      });
+      expect(r.status).toBe(401);
+    }
+    const blocked = await fetch(`${baseUrl}/comment-handles/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: "regular2", password: "wrongpassword" }),
+    });
+    expect(blocked.status).toBe(429);
+  });
+});
+
+describe("GET /comment-handles/me", () => {
+  test("returns 401 without a cookie", async () => {
+    const res = await fetch(`${baseUrl}/comment-handles/me`);
+    expect(res.status).toBe(401);
+  });
+
+  test("returns the handle's id and username with a valid cookie", async () => {
+    const handleToken = signHandleToken({ handleId: 1, username: "regular" });
+    const res = await fetch(`${baseUrl}/comment-handles/me`, {
+      headers: { Cookie: `handleToken=${handleToken}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.handleId).toBe(1);
+    expect(body.username).toBe("regular");
+  });
+});

--- a/tests/routes/comments.test.ts
+++ b/tests/routes/comments.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, beforeAll, afterAll, afterEach } from "bun:test
 import { app } from "../../server/server";
 import { prisma } from "../../server/db/events";
 import { makeUser, authCookie } from "../helpers/auth";
+import { signHandleToken } from "../../server/auth/handleSession";
 
 let server: ReturnType<typeof app.listen>;
 let baseUrl: string;
@@ -16,6 +17,7 @@ afterAll(async () => {
 });
 afterEach(async () => {
   await prisma.comment.deleteMany();
+  await prisma.commentHandle.deleteMany();
   await prisma.event.deleteMany();
   await prisma.user.deleteMany();
   await prisma.invite.deleteMany();
@@ -34,17 +36,6 @@ async function makeEvent(ownerId: number) {
 }
 
 describe("POST /event/:id/comments", () => {
-  test("rejects unauthenticated with 401", async () => {
-    const owner = await makeUser();
-    const event = await makeEvent(owner.id);
-    const res = await fetch(`${baseUrl}/event/${event.id}/comments`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ body: "hi" }),
-    });
-    expect(res.status).toBe(401);
-  });
-
   test("creates a comment when authenticated (201)", async () => {
     const user = await makeUser("CONTRIBUTOR", "katja");
     const event = await makeEvent(user.id);
@@ -78,6 +69,131 @@ describe("POST /event/:id/comments", () => {
       body: JSON.stringify({ body: "hi" }),
     });
     expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /event/:id/comments — anonymous", () => {
+  test("posts with a free-typed name, no session created", async () => {
+    const owner = await makeUser();
+    const event = await makeEvent(owner.id);
+    const res = await fetch(`${baseUrl}/event/${event.id}/comments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ body: "see you there", name: "Some Visitor" }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.displayName).toBe("Some Visitor");
+    expect(body.author).toBeNull();
+    expect(body.handle).toBeNull();
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+
+  test("posts with no name at all", async () => {
+    const owner = await makeUser();
+    const event = await makeEvent(owner.id);
+    const res = await fetch(`${baseUrl}/event/${event.id}/comments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ body: "hi" }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.displayName).toBeNull();
+  });
+
+  test("rejects a name that collides with a real user's username (409)", async () => {
+    const owner = await makeUser("CONTRIBUTOR", "katja");
+    const event = await makeEvent(owner.id);
+    const res = await fetch(`${baseUrl}/event/${event.id}/comments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ body: "hi", name: "katja" }),
+    });
+    expect(res.status).toBe(409);
+  });
+
+  test("reserve+comment creates a CommentHandle and sets a handleToken cookie", async () => {
+    const owner = await makeUser();
+    const event = await makeEvent(owner.id);
+    const res = await fetch(`${baseUrl}/event/${event.id}/comments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        body: "hi",
+        name: "regular",
+        reserve: true,
+        password: "a-decent-passphrase",
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.handle.username).toBe("regular");
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("handleToken=");
+    expect(setCookie.toLowerCase()).toContain("httponly");
+    expect(await prisma.commentHandle.findUnique({ where: { username: "regular" } })).not.toBeNull();
+  });
+
+  test("reserving an already-reserved name fails and posts no comment", async () => {
+    const owner = await makeUser();
+    const event = await makeEvent(owner.id);
+    await prisma.commentHandle.create({
+      data: { username: "regular", passwordHash: await Bun.password.hash("whatever12345") },
+    });
+    const res = await fetch(`${baseUrl}/event/${event.id}/comments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        body: "hi",
+        name: "regular",
+        reserve: true,
+        password: "a-decent-passphrase",
+      }),
+    });
+    expect(res.status).toBe(409);
+    expect(await prisma.comment.count({ where: { eventId: event.id } })).toBe(0);
+  });
+
+  test("an existing handle session posts under that handle, ignoring a different typed name", async () => {
+    const owner = await makeUser();
+    const event = await makeEvent(owner.id);
+    const handle = await prisma.commentHandle.create({
+      data: { username: "regular", passwordHash: await Bun.password.hash("whatever12345") },
+    });
+    const handleToken = signHandleToken({ handleId: handle.id, username: handle.username });
+    const res = await fetch(`${baseUrl}/event/${event.id}/comments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: `handleToken=${handleToken}` },
+      body: JSON.stringify({ body: "hi", name: "different name" }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.handle.username).toBe("regular");
+  });
+
+  test("blocks after the per-IP anonymous rate limit is hit (429)", async () => {
+    const owner = await makeUser();
+    const event = await makeEvent(owner.id);
+    // A dedicated X-Forwarded-For value keeps this test's rate-limit bucket
+    // isolated from the other anonymous-posting tests above, which all share
+    // the real loopback IP (app.proxy = true, same as in production behind
+    // nginx, means ctx.ip trusts this header).
+    const headers = { "Content-Type": "application/json", "X-Forwarded-For": "203.0.113.50" };
+    for (let i = 0; i < 20; i++) {
+      const r = await fetch(`${baseUrl}/event/${event.id}/comments`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ body: `msg ${i}` }),
+      });
+      expect(r.status).toBe(201);
+    }
+    const blocked = await fetch(`${baseUrl}/event/${event.id}/comments`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ body: "one too many" }),
+    });
+    expect(blocked.status).toBe(429);
   });
 });
 
@@ -151,6 +267,65 @@ describe("DELETE /comment/:id", () => {
       headers: { Cookie: authCookie(user) },
     });
     expect(res.status).toBe(404);
+  });
+});
+
+describe("DELETE /comment/:id — handle-authored", () => {
+  test("the owning handle session can delete its own comment", async () => {
+    const owner = await makeUser();
+    const event = await makeEvent(owner.id);
+    const handle = await prisma.commentHandle.create({
+      data: { username: "regular", passwordHash: await Bun.password.hash("whatever12345") },
+    });
+    const c = await prisma.comment.create({ data: { eventId: event.id, body: "x", handleId: handle.id } });
+    const handleToken = signHandleToken({ handleId: handle.id, username: handle.username });
+    const res = await fetch(`${baseUrl}/comment/${c.id}`, {
+      method: "DELETE",
+      headers: { Cookie: `handleToken=${handleToken}` },
+    });
+    expect(res.status).toBe(204);
+  });
+
+  test("a different handle session cannot delete it (403)", async () => {
+    const owner = await makeUser();
+    const event = await makeEvent(owner.id);
+    const handle = await prisma.commentHandle.create({
+      data: { username: "regular", passwordHash: await Bun.password.hash("whatever12345") },
+    });
+    const otherHandle = await prisma.commentHandle.create({
+      data: { username: "someoneelse", passwordHash: await Bun.password.hash("whatever12345") },
+    });
+    const c = await prisma.comment.create({ data: { eventId: event.id, body: "x", handleId: handle.id } });
+    const otherToken = signHandleToken({ handleId: otherHandle.id, username: otherHandle.username });
+    const res = await fetch(`${baseUrl}/comment/${c.id}`, {
+      method: "DELETE",
+      headers: { Cookie: `handleToken=${otherToken}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("a plain anonymous unclaimed-name comment cannot be deleted without a session (401)", async () => {
+    const owner = await makeUser();
+    const event = await makeEvent(owner.id);
+    const c = await prisma.comment.create({
+      data: { eventId: event.id, body: "x", displayName: "someone" },
+    });
+    const res = await fetch(`${baseUrl}/comment/${c.id}`, { method: "DELETE" });
+    expect(res.status).toBe(401);
+  });
+
+  test("an admin can still delete any comment regardless of authorship type", async () => {
+    const owner = await makeUser();
+    const admin = await makeUser("ADMIN");
+    const event = await makeEvent(owner.id);
+    const c = await prisma.comment.create({
+      data: { eventId: event.id, body: "x", displayName: "someone" },
+    });
+    const res = await fetch(`${baseUrl}/comment/${c.id}`, {
+      method: "DELETE",
+      headers: { Cookie: authCookie(admin) },
+    });
+    expect(res.status).toBe(204);
   });
 });
 


### PR DESCRIPTION
## Summary
- Comments no longer require an invited account — anyone can post, optionally under a free-typed display name.
- A name can be reserved with a password (like IRC's NickServ), giving it a permanent, protected identity (`CommentHandle`) separate from real `User` accounts. The handle session uses its own JWT, cryptographically isolated from the real login token (derived key, own cookie), so it can never be mistaken for a real authenticated session.
- Events, editing, and deletion by real users are untouched — this only opens up the comment write path.
- Fixes the original bug where the comment form required being logged in just to be *visible* (a CSS specificity conflict between `#commentForm { display: flex }` and the `[hidden]` attribute), by making the form always render regardless of auth state.

Design spec: `docs/superpowers/specs/2026-09-08-anonymous-comment-handles-design.md`
Implementation plan: `docs/superpowers/plans/2026-09-08-anonymous-comment-handles.md`

## Test plan
- [x] Full automated suite passes (139 tests: domain, routes, auth/session isolation)
- [x] Manual browser walkthrough of every state: logged-out visible form, anonymous with/without a name, name reservation + login persistence across reload, 409 conflict → inline login → auto-resubmit, handle-owned delete vs. admin-only delete of unclaimed comments, logged-in view hides the anonymous UI entirely